### PR TITLE
検索履歴周りを管理するAPIを追加

### DIFF
--- a/gateway/graph/schema.graphqls
+++ b/gateway/graph/schema.graphqls
@@ -1,6 +1,10 @@
+# v0.0.1a
+
 type Query {
-  verifyUser(user: User!): Boolean!
-  findTrend(word: String!): [Suggest!]!
+  verifyUser(user: User!): String! # ログインTokenを返却
+  trendSearch(word: String!): Int! # SuggestテーブルIDを返却 => 検索履歴欄にてkeywordと組み合わせて保持
+  trendHistory: [History]! # ユーザーIDに紐づく検索履歴を返却 => ユーザー認証はCookie内のTokenで行う/履歴がない場合は空配列が返る（日時更新）
+  trendSuggest(suggestId: Int!): [Suggest!]!
 }
 
 type Mutation {
@@ -10,6 +14,16 @@ type Mutation {
 input User {
   email: String!
   password: String!
+}
+
+type History {
+  suggestId: Int!
+  status: Progress!
+}
+
+enum Progress {
+  INPROGRESS
+  COMPLETED
 }
 
 type Suggest {

--- a/gateway/graph/schema.graphqls
+++ b/gateway/graph/schema.graphqls
@@ -2,7 +2,7 @@
 
 type Query {
   verifyUser(user: User!): String!
-  trendSearch(word: String!): Int!
+  trendSearch(keyword: String!): Int!
   trendHistory: [History]!
   trendSuggest(suggestId: Int!): [Suggest!]!
 }
@@ -27,7 +27,7 @@ enum Progress {
 }
 
 type Suggest {
-  word: String!
+  keyword: String!
   childSuggests: [ChildSuggest!]!
 }
 

--- a/gateway/graph/schema.graphqls
+++ b/gateway/graph/schema.graphqls
@@ -1,9 +1,9 @@
 # v0.0.1a
 
 type Query {
-  verifyUser(user: User!): String! # ログインTokenを返却
-  trendSearch(word: String!): Int! # SuggestテーブルIDを返却 => 検索履歴欄にてkeywordと組み合わせて保持
-  trendHistory: [History]! # ユーザーIDに紐づく検索履歴を返却 => ユーザー認証はCookie内のTokenで行う/履歴がない場合は空配列が返る（日時更新）
+  verifyUser(user: User!): String!
+  trendSearch(word: String!): Int!
+  trendHistory: [History]!
   trendSuggest(suggestId: Int!): [Suggest!]!
 }
 

--- a/mysql/init/trend.sql
+++ b/mysql/init/trend.sql
@@ -7,12 +7,13 @@ DROP TABLE IF EXISTS suggest;
 CREATE TABLE suggest (
   id INT unsigned NOT NULL auto_increment,
   keyword VARCHAR(255) NOT NULL,
+  date DATE NOT NULL,
   result json DEFAULT NULL,
   status tinyint(1) NOT NULL DEFAULT 0,
   created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
   updated_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (id),
-  UNIQUE KEY (keyword)
+  UNIQUE KEY (keyword, date)
 ) COMMENT 'サジェストキーワード';
 
 DROP TABLE IF EXISTS history;


### PR DESCRIPTION
## TrendAPIシリーズ

作成しました

```
type Query {
  verifyUser(user: User!): String! # ログインTokenを返却
  trendSearch(word: String!): Int! # SuggestIDを返却 => 検索履歴欄にてkeywordと組み合わせて保持
  trendHistory: [History]! # ユーザーIDに紐づく検索履歴を返却 => ユーザー認証はCookie内のTokenで行う/履歴がない場合は空配列が返る（日時更新）
  trendSuggest(suggestId: Int!): [Suggest!]! サジェスト内容を返却 => 検索履歴欄にて保持しておいたSuggestIDを引数に渡す
}
```

TrendDBスキーマは以下の通り
https://github.com/originbenntou/2929BE/blob/master/mysql/init/trend.sql

## DBテスト

```
mysql> INSERT INTO suggest (keyword, date, result, status) VALUES ('コロナ', '20200417', '{"test":"json"}', 1);
Query OK, 1 row affected (0.02 sec)

mysql> SELECT * FROM suggest;
+----+-----------+------------+------------------+--------+---------------------+---------------------+
| id | keyword   | date       | result           | status | created_at          | updated_at          |
+----+-----------+------------+------------------+--------+---------------------+---------------------+
|  1 | コロナ    | 2020-04-17 | {"test": "json"} |      1 | 2020-04-17 12:56:10 | 2020-04-17 12:56:10 |
+----+-----------+------------+------------------+--------+---------------------+---------------------+
1 row in set (0.00 sec)

mysql> INSERT INTO suggest (keyword, date, result, status) VALUES ('コロナ', '20200417', '{"test":"cson"}', 1);
ERROR 1062 (23000): Duplicate entry 'コロナ-2020-04-17' for key 'keyword'
mysql> INSERT INTO suggest (keyword, date, result, status) VALUES ('コロナ', '20200418', '{"test":"json"}', 1);
Query OK, 1 row affected (0.01 sec)
mysql> INSERT INTO suggest (keyword, date, result, status) VALUES ('コロナパワー', '20200417', '{"test":"cson"}', 1);
Query OK, 1 row affected (0.02 sec)

```

## TODO

- TrendDBスキーマを資料に落とす
- APIシーケンス図（的なもの）はソタ君お願いします...！！